### PR TITLE
Add AUR to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Preview and debug websites metadata tags for social media share.
 
 | Distribution | Package | Maintainer |
 |:-:|:-:|:-:|
+| Arch Linux (AUR) | [share-preview](https://aur.archlinux.org/packages/share-preview), [share-preview-bin](https://aur.archlinux.org/packages/share-preview-bin) | [Archisman Panigrahi](https://github.com/apandada1/) |
 
 
 ## Build from source


### PR DESCRIPTION
I have made two AUR packages for Arch Linux and derivatives.

The package `share-preview` downloads the source and compiles with Rust (it takes quite a while to compile, and the compiled libraries take 2.5 GB space, like most other Rust apps :worried:. However they can be easily cleaned with the package manager. ).

That is why, I have also made the `share-preview-bin` package with the compiled binary (only a 2 MB download :smiley:, and 5.8 MB when installed  ). I have uploaded the compiled binary to [my fork](https://github.com/apandada1/share-preview/releases/tag/0.1.2).