### PR TITLE
Desktop file: Add comment & keywords

### DIFF
--- a/data/com.rafaelmardojai.SharePreview.desktop.in.in
+++ b/data/com.rafaelmardojai.SharePreview.desktop.in.in
@@ -1,11 +1,11 @@
 [Desktop Entry]
 Name=Share Preview
-Comment=
+Comment=Test social media cards locally
 Type=Application
 Exec=share-preview
 Terminal=false
 Categories=Utility;GNOME;GTK;
-Keywords=Gnome;GTK;
+Keywords=Gnome;GTK;link;url;unfurl;
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=@icon@
 StartupNotify=true


### PR DESCRIPTION
I keep forgetting what this app is called, and searching for terms like “social” and “link” to find it. The term "social” appears in the appstream file, but not in the desktop file. The Comment and Keywords fields are used (in addition to the app's name) when performing a desktop search on GNOME.

The AppStream <comment> field is defined as follows:

> A short summary on what this application does, roughly equivalent to the Comment field of the accompanying .desktop file of the application.

https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Application.html#tag-dapp-summary

So it is reasonable (and in my experience quite common) to set the desktop file's comment to the same string. This also means that the same translations can be used in both places.

I have added the other terms that come to mind to the desktop file's keywords. "Unfurl" is [the term that Slack uses](https://api.slack.com/docs/message-link-unfurling). The others are, I hope, self-explanatory. At build time, the keywords from the .desktop file will be added to the repository (eg Flathub)'s appstream XML, so the app will be findable in GNOME Software with these terms as well.

(Personally I would remove the terms "GNOME" and "GTK" from the keywords.)