### PR TITLE
UI: Fix GNOME HIG issue

### DIFF
--- a/data/resources/ui/window.ui
+++ b/data/resources/ui/window.ui
@@ -83,7 +83,7 @@
                             <property name="hexpand">true</property>
                             <property name="secondary-icon-name">go-next-symbolic</property>
                             <property name="secondary-icon-sensitive">false</property>
-                            <property name="secondary-icon-tooltip-text" translatable="yes">Go...</property>
+                            <property name="secondary-icon-tooltip-text" translatable="yes">Go</property>
                           </object>
                         </child>
                       </object>
@@ -184,7 +184,7 @@
                                 <property name="icon-name">system-search-symbolic</property>
                                 <property name="halign">center</property>
                                 <property name="valign">end</property>
-                                <property name="tooltip-text" translatable="yes">View Found Data...</property>
+                                <property name="tooltip-text" translatable="yes">View Found Data</property>
                                 <style>
                                   <class name="pill"/>
                                 </style>


### PR DESCRIPTION
To short: We don't need to add ellipses for actions.

Ellipses useful when "if further input or confirmation is required from the user before the action can be carried out".

https://developer.gnome.org/hig/guidelines/writing-style.html