### PR TITLE
help-overlay: Remove excessive action

### DIFF
--- a/data/resources/resources.gresource.xml
+++ b/data/resources/resources.gresource.xml
@@ -5,7 +5,7 @@
     <file compressed="true">style.css</file>
 
     <!-- UI -->
-    <file compressed="true" preprocess="xml-stripblanks" alias="shortcuts.ui">ui/shortcuts.ui</file>
+    <file compressed="true" preprocess="xml-stripblanks" alias="gtk/help-overlay.ui">ui/shortcuts.ui</file>
     <file compressed="true" preprocess="xml-stripblanks" alias="window.ui">ui/window.ui</file>
     <file compressed="true" preprocess="xml-stripblanks" alias="card.ui">ui/card.ui</file>
     <file compressed="true" preprocess="xml-stripblanks" alias="image.ui">ui/image.ui</file>

--- a/data/resources/ui/shortcuts.ui
+++ b/data/resources/ui/shortcuts.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <object class="GtkShortcutsWindow" id="shortcuts">
+  <object class="GtkShortcutsWindow" id="help_overlay">
     <property name="modal">True</property>
     <child>
       <object class="GtkShortcutsSection">

--- a/src/application.rs
+++ b/src/application.rs
@@ -115,7 +115,6 @@ impl SharePreviewApplication {
     // Sets up keyboard shortcuts
     fn setup_accels(&self) {
         self.set_accels_for_action("app.quit", &["<primary>q"]);
-        self.set_accels_for_action("win.show-help-overlay", &["<primary>question"]);
     }
 
     fn show_about_dialog(&self) {

--- a/src/window.rs
+++ b/src/window.rs
@@ -87,11 +87,6 @@ mod imp {
         fn constructed(&self, obj: &Self::Type) {
             self.parent_constructed(obj);
 
-            let builder =
-                gtk::Builder::from_resource("/com/rafaelmardojai/SharePreview/shortcuts.ui");
-            let shortcuts = builder.object("shortcuts").unwrap();
-            obj.set_help_overlay(Some(&shortcuts));
-
             // Devel Profile
             if PROFILE == "Devel" {
                 obj.style_context().add_class("devel");


### PR DESCRIPTION
We don't need an extra action to show help-overlay. It already managed by GTK.

Source: https://docs.gtk.org/gtk4/class.Application.html#automatic-resources