### PR TITLE
misc: update GNOME Circle URL

### DIFF
--- a/data/com.rafaelmardojai.SharePreview.metainfo.xml.in.in
+++ b/data/com.rafaelmardojai.SharePreview.metainfo.xml.in.in
@@ -20,7 +20,7 @@
       <image>https://github.com/rafaelmardojai/share-preview/raw/master/brand/screenshot-3.png</image>
     </screenshot>
   </screenshots>
-  <url type="homepage">https://apps.gnome.org/app/com.rafaelmardojai.SharePreview/</url>
+  <url type="homepage">https://apps.gnome.org/SharePreview/</url>
   <url type="bugtracker">https://github.com/rafaelmardojai/share-preview/issues</url>
   <url type="donation">https://mardojai.com/donate/</url>
   <url type="translate">https://hosted.weblate.org/engage/share-preview/</url>

--- a/src/application.rs
+++ b/src/application.rs
@@ -106,7 +106,7 @@ impl SharePreviewApplication {
             .application_name(&gettext("Share Preview"))
             .application_icon(config::APP_ID)
             .license_type(gtk::License::Gpl30)
-            .website("https://apps.gnome.org/app/com.rafaelmardojai.SharePreview/")
+            .website("https://apps.gnome.org/SharePreview/")
             .version(config::VERSION)
             .developers(vec!["Rafael Mardojai CM https://mardojai.com".to_string()])
             .artists(vec!["Rafael Mardojai CM https://mardojai.com".to_string(), "Tobias Bernard".to_string()])


### PR DESCRIPTION
Use the new simplified URL for apps.gnome.org.