### PR TITLE
appdata: Improve appdata for AppStream 1.0

### DIFF
--- a/data/com.rafaelmardojai.SharePreview.metainfo.xml.in.in
+++ b/data/com.rafaelmardojai.SharePreview.metainfo.xml.in.in
@@ -25,7 +25,7 @@
   <url type="donation">https://mardojai.com/donate/</url>
   <url type="translate">https://hosted.weblate.org/engage/share-preview/</url>
   <url type="vcs-browser">https://github.com/rafaelmardojai/share-preview/</url>
-  <content_rating type="oars-1.0" />
+  <content_rating type="oars-1.1" />
   <releases>
     <release version="0.4.0" date="2023-09-29">
       <description translatable="no">
@@ -89,14 +89,18 @@
      <kudo>HiDpiIcon</kudo>
   </kudos>
   <requires>
-    <display_length compare="ge">medium</display_length>
+    <display_length compare="ge">524</display_length>
   </requires>
   <recommends>
     <control>keyboard</control>
     <control>pointing</control>
     <control>touch</control>
   </recommends>
-  <developer_name>Rafael Mardojai CM</developer_name>
+  <!-- developer_name tag deprecated with Appstream 1.0 -->
+  <developer_name translatable="no">Rafael Mardojai CM</developer_name>
+  <developer id="gitlab.com">
+    <name translatable="no">Rafael Mardojai CM</name>
+  </developer>
   <update_contact>email@rafaelmardojai.com</update_contact>
   <translation type="gettext">@gettext-package@</translation>
   <launchable type="desktop-id">@app-id@.desktop</launchable>

--- a/data/meson.build
+++ b/data/meson.build
@@ -43,9 +43,8 @@ appdata_file = i18n.merge_file(
 if appstreamcli.found()
   test(
     'validate-appdata', appstreamcli,
-    args: [
-      'validate', '--no-net', appdata_file.full_path()
-    ]
+    args: ['validate', '--no-net', '--explain', appdata_file],
+    workdir: meson.current_build_dir()
   )
 endif
 


### PR DESCRIPTION
- Add the `<developer><name>` tag
- Mark the `<developer_name>` tag as deprecated
- Mark the developer name as untranslatable
- Update oars version
- Improve appstreamcli arguments
- Update named display_length