### PR TITLE
metainfo: Fix screen size requirement

### DIFF
--- a/data/com.rafaelmardojai.SharePreview.metainfo.xml.in.in
+++ b/data/com.rafaelmardojai.SharePreview.metainfo.xml.in.in
@@ -104,7 +104,7 @@
      <kudo>HiDpiIcon</kudo>
   </kudos>
   <requires>
-    <display_length compare="ge">524</display_length>
+    <display_length compare="eq">524</display_length>
   </requires>
   <recommends>
     <control>keyboard</control>


### PR DESCRIPTION
Indicate that the screen size must be exactly equal to the given value.