### PR TITLE
Rename new-window action

### DIFF
--- a/data/resources/ui/window.ui
+++ b/data/resources/ui/window.ui
@@ -4,7 +4,7 @@
     <section>
       <item>
         <attribute name="label" translatable="yes">_New Window</attribute>
-        <attribute name="action">app.new</attribute>
+        <attribute name="action">app.new-window</attribute>
       </item>
     </section>
     <section>

--- a/src/application.rs
+++ b/src/application.rs
@@ -95,7 +95,7 @@ impl SharePreviewApplication {
         // New Window
         action!(
             self,
-            "new",
+            "new-window",
             clone!(
                 #[weak(rename_to = app)]
                 self,
@@ -110,7 +110,7 @@ impl SharePreviewApplication {
     // Sets up keyboard shortcuts
     fn setup_accels(&self) {
         self.set_accels_for_action("app.quit", &["<primary>q"]);
-        self.set_accels_for_action("app.new", &["<primary>n"]);
+        self.set_accels_for_action("app.new-window", &["<primary>n"]);
         self.set_accels_for_action("win.url", &["<primary>l"]);
     }
 


### PR DESCRIPTION
GNOME Shell uses the "new-window" action to open new main windows for an application. Using that action name allows the application launcher to detect the action, and provide a "New Window" menu entry for the user.