### PR TITLE
application: Present active window if available

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -33,6 +33,13 @@ mod imp {
 
     impl ApplicationImpl for SharePreviewApplication {
         fn activate(&self) {
+            self.parent_activate();
+
+            if let Some(win) = self.obj().active_window() {
+                win.present();
+                return;
+            }
+
             let win = self.obj().create_window();
             win.present();
         }


### PR DESCRIPTION
Instead of creating new one, raise the existing one on activation.