### PR TITLE
fix(app): Create new window if requested

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -84,7 +84,11 @@ mod imp {
                     win.open_uri(uri.to_str().unwrap());
                 }
             } else {
-                self.activate();
+                if new_window {
+                    self.obj().activate_action("new-window", None);
+                } else {
+                    self.activate();
+                }
             }
 
             glib::ExitCode::SUCCESS


### PR DESCRIPTION
It needs to be handled even if no URL is specified. Without this, the new-window action does not work.