### PR TITLE
Add official Arch package

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Preview and debug websites metadata tags for social media share.
 
 | Distribution | Package | Maintainer |
 |:-:|:-:|:-:|
-| Arch Linux (AUR) | [share-preview](https://aur.archlinux.org/packages/share-preview), [share-preview-bin](https://aur.archlinux.org/packages/share-preview-bin) | [Archisman Panigrahi](https://github.com/apandada1/) |
+| Arch Linux | [share-preview](https://archlinux.org/packages/share-preview) | [Balló György](https://archlinux.org/packages/?packager=bgyorgy) |
 
 
 ## Build from source


### PR DESCRIPTION
Share Preview is now on official Arch Linux repositories (instead of AUR)