### PR TITLE
Add D-Bus service file

### DIFF
--- a/data/com.rafaelmardojai.SharePreview.desktop.in.in
+++ b/data/com.rafaelmardojai.SharePreview.desktop.in.in
@@ -10,6 +10,7 @@ Keywords=Gnome;GTK;link;url;unfurl;
 # Translators: Do NOT translate or transliterate this text (this is an icon file name)!
 Icon=@icon@
 StartupNotify=true
+DBusActivatable=true
 Actions=new-window;
 
 [Desktop Action new-window]

--- a/data/com.rafaelmardojai.SharePreview.service.in
+++ b/data/com.rafaelmardojai.SharePreview.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=@app-id@
+Exec=@bindir@/share-preview --gapplication-service

--- a/data/meson.build
+++ b/data/meson.build
@@ -70,5 +70,16 @@ if glib_compile_schemas.found()
   )
 endif
 
+# D-Bus service file
+service_conf = configuration_data()
+service_conf.set('app-id', application_id)
+service_conf.set('bindir', bindir)
+configure_file(
+  input: '@0@.service.in'.format(base_id),
+  output: '@0@.service'.format(application_id),
+  configuration: service_conf,
+  install_dir: datadir / 'dbus-1' / 'services'
+)
+
 subdir('icons')
 subdir('resources')


### PR DESCRIPTION
And mark the application as D-Bus activatable. This allows application launchers to activate it via D-Bus.

Reference:
https://specifications.freedesktop.org/desktop-entry-spec/1.3/dbus.html